### PR TITLE
Correct namespace

### DIFF
--- a/src/String/Test/NormaliseTest.php
+++ b/src/String/Test/NormaliseTest.php
@@ -6,7 +6,7 @@
 
 // phpcs:disable
 
-namespace Windwalker\String\Tests;
+namespace Windwalker\String\Test;
 
 use Windwalker\String\StringNormalise;
 


### PR DESCRIPTION
Referenced over at https://github.com/windwalker-io/string/pull/1 which I think is a subtree of the 3.x branch. This is causing warnings in Composer, so would be nice to clean up.